### PR TITLE
Allow peers from the same IP, on a different port

### DIFF
--- a/peer.cpp
+++ b/peer.cpp
@@ -52,7 +52,8 @@ int btBasic::IpEquiv(struct sockaddr_in addr)
 //  CONSOLE.Debug_n("%s", inet_ntoa(addr.sin_addr));
 //  CONSOLE.Debug_n();
   return
-    (memcmp(&m_sin.sin_addr, &addr.sin_addr, sizeof(struct in_addr)) == 0) ?
+    (memcmp(&m_sin.sin_addr, &addr.sin_addr, sizeof(struct in_addr)) == 0
+     && m_sin.sin_port == addr.sin_port) ?
       1 : 0;
 }
 


### PR DESCRIPTION
When [adding peers](https://github.com/zorkian/dtorrent/blob/b6a6a4312685eccb0ecb5d71df2f44bd9ca2b601/tracker.cpp#L230) provided by the tracker, ctorrent ignores peers from the same IP address (IpEquiv), so you cannot have a peer from a different port on the same IP. This change makes it only ignore peers from the same IP and port.
