### PR TITLE
Add Bazel BUILD rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.status
 ctorrent
 stamp-h1
 Makefile
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,27 @@
+cc_binary(
+    name = "dtorrent",
+    srcs = ['config.h'] + glob(["*.cpp"]) + glob(["*.c"]) + glob(["*.h"]),
+    copts = [
+        '-fpermissive', # code has some const violations
+    ],
+    linkopts = [
+        '-lrt',
+        '-lssl',
+    ],
+)
+
+genrule(
+    name = 'config',
+    srcs = [
+        'ctorrent.cpp',
+        'config.h.in',
+        'install-sh',
+        'Makefile.in',
+        'missing',
+    ],
+    outs = [
+        'config.h',
+    ],
+    cmd = '$(location configure); cp config.h $@',
+    tools = ['configure'],
+)


### PR DESCRIPTION
Adds a bazel BUILD rule for building the dtorrent binary. This is useful because we can then depend on it as a Bazel data dep.

```
$ bazel build dtorrent
INFO: Reading 'startup' options from /usr/bin/bazel-bin.bazel-binrc: --host_jvm_args=-Xmx1024m --host_jvm_args=-Dbazel.DigestFunction=SHA1 --deep_execroot
INFO: Reading 'startup' options from /etc/bazel.bazelrc: --host_jvm_args=-Xmx2048m
INFO: Found 1 target...
Target //:dtorrent up-to-date:
  bazel-bin/dtorrent
INFO: Elapsed time: 0.412s, Critical Path: 0.02s
```